### PR TITLE
initrd: Update submodule

### DIFF
--- a/rpm/droid-hal-pdx213-img-boot.spec
+++ b/rpm/droid-hal-pdx213-img-boot.spec
@@ -9,7 +9,4 @@
 
 %define lvm_root_size 5000
 
-# mkbootimg needs python
-BuildRequires:  python
-
 %include initrd/droid-hal-device-img-boot.inc


### PR DESCRIPTION
- [initrd] Add support for creating custom vendor_boot image
- [initrd] Only pull in droid-hal-tools in if needed, else use shared mkbootimg. JB#51936